### PR TITLE
Updated path for built Soundflower.kext

### DIFF
--- a/Tools/build.rb
+++ b/Tools/build.rb
@@ -48,9 +48,9 @@ Open3.popen3("sudo xcodebuild -project Soundflower.xcodeproj -target Soundflower
   err = stderr.read
 end
 
-`sudo chown -R root  #{@svn_root}/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext`
-`sudo chgrp -R wheel #{@svn_root}/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext`
-`sudo chmod -R 755   #{@svn_root}/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext`
+`sudo chown -R root  #{@svn_root}/Build/InstallerRoot/Library/Extensions/Soundflower.kext`
+`sudo chgrp -R wheel #{@svn_root}/Build/InstallerRoot/Library/Extensions/Soundflower.kext`
+`sudo chmod -R 755   #{@svn_root}/Build/InstallerRoot/Library/Extensions/Soundflower.kext`
 
 #if /BUILD SUCCEEDED/.match(out)
 #  puts "    BUILD SUCCEEDED"

--- a/Tools/installer.rb
+++ b/Tools/installer.rb
@@ -33,7 +33,7 @@ def create_logs
   @error_log.flush
   trap("SIGINT") { die }
 end
-  
+
 def die
   close_logs
   exit 0
@@ -61,7 +61,7 @@ end
 def cmd(commandString)
   out = ""
   err = ""
-  
+
   Open3.popen3(commandString) do |stdin, stdout, stderr|
     out = stdout.read
     err = stderr.read
@@ -74,11 +74,11 @@ end
 def getversion()
   theVersion = "0.0.0"
 
-  f = File.open("#{@installer_root}/System/Library/Extensions/Soundflower.kext/Contents/Info.plist", "r")
+  f = File.open("#{@installer_root}/Library/Extensions/Soundflower.kext/Contents/Info.plist", "r")
   str = f.read
   theVersion = str.match(/<key>CFBundleShortVersionString<\/key>\n.*<string>(.*)<\/string>/).captures[0]
   f.close
-  
+
   puts"  version: #{theVersion}"
   return theVersion;
 end


### PR DESCRIPTION
When building Soundflower, I got these errors:

```
~/git/Soundflower/Tools$ ./build.rb dep
  Building the new Soundflower.kext with Xcode
chown: ../Build/InstallerRoot/System/Library/Extensions/Soundflower.kext: No such file or directory
chgrp: ../Build/InstallerRoot/System/Library/Extensions/Soundflower.kext: No such file or directory
chmod: ../Build/InstallerRoot/System/Library/Extensions/Soundflower.kext: No such file or directory
  Building the new Soundflowerbed.app with Xcode
    BUILD SUCCEEDED
  Done.
```

and

```
~/git/Soundflower/Tools$ ./installer.rb
./installer.rb:77:in `initialize': No such file or directory - /Users/larstobi/git/Soundflower/Build/InstallerRoot/System/Library/Extensions/Soundflower.kext/Contents/    Info.plist (Errno::ENOENT)
    from ./installer.rb:77:in `open'
    from ./installer.rb:77:in `getversion'
    from ./installer.rb:93:in `<main>'
```

This patch updates the paths so that the build and installer scripts can find the kernel extension.
